### PR TITLE
update flickr auth urls to https

### DIFF
--- a/lib/passport-flickr/strategy.js
+++ b/lib/passport-flickr/strategy.js
@@ -41,9 +41,9 @@ var util = require('util')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.requestTokenURL = options.requestTokenURL || 'http://www.flickr.com/services/oauth/request_token';
-  options.accessTokenURL = options.accessTokenURL || 'http://www.flickr.com/services/oauth/access_token';
-  options.userAuthorizationURL = options.userAuthorizationURL || 'http://www.flickr.com/services/oauth/authorize?perms=read';
+  options.requestTokenURL = options.requestTokenURL || 'https://www.flickr.com/services/oauth/request_token';
+  options.accessTokenURL = options.accessTokenURL || 'https://www.flickr.com/services/oauth/access_token';
+  options.userAuthorizationURL = options.userAuthorizationURL || 'https://www.flickr.com/services/oauth/authorize?perms=read';
   options.sessionKey = options.sessionKey || 'oauth:flickr';
 
   OAuthStrategy.call(this, options, verify);


### PR DESCRIPTION
Hi, we've updated all of our API endpoints to support https, and plan on restricting the API to https later this year. This change should make everything good.
