### PR TITLE
Allowing the use of different permissions upon authentication

### DIFF
--- a/lib/passport-flickr/strategy.js
+++ b/lib/passport-flickr/strategy.js
@@ -43,7 +43,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.requestTokenURL = options.requestTokenURL || 'https://www.flickr.com/services/oauth/request_token';
   options.accessTokenURL = options.accessTokenURL || 'https://www.flickr.com/services/oauth/access_token';
-  options.userAuthorizationURL = options.userAuthorizationURL || 'https://www.flickr.com/services/oauth/authorize?perms=read';
+  options.userAuthorizationURL = options.userAuthorizationURL || 'https://www.flickr.com/services/oauth/authorize?perms=' + (options.perms || 'read');
   options.sessionKey = options.sessionKey || 'oauth:flickr';
 
   OAuthStrategy.call(this, options, verify);


### PR DESCRIPTION
As suggested by @lontongcorp back in September 2013 (#2), can we change this to allow the changing of permission scope? It's really simple to do and pretty much a requirement!
